### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 MODULE_big = redis_fdw
 OBJS = redis_fdw.o
 
-EXTENTION = redis_fdw
+EXTENSION = redis_fdw
+DATA = redis_fdw--1.0.sql
 
 SHLIB_LINK += -lhiredis
 


### PR DESCRIPTION
Hello! I believe there is typo in Makefile that prevents correct installation in postgres.