### PR TITLE
Support sending a pattern to the KEYS command

### DIFF
--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -2843,8 +2843,14 @@ redisIterateForeignScan(ForeignScanState *node)
 			rctx->cmd = REDIS_PSNUMSUB;
 			break;
 		case PG_REDIS_KEYS:
-			DEBUG((DEBUG_LEVEL, "KEYS *"));
-			rctx->r_reply = redisCommand(ctx, "KEYS *");
+			if (NULL != rctx->key) {
+				DEBUG((DEBUG_LEVEL, "KEYS %s", rctx->key));
+				rctx->r_reply = redisCommand(ctx, "KEYS %s", rctx->key);
+			}
+			else {
+				DEBUG((DEBUG_LEVEL, "KEYS *"));
+				rctx->r_reply = redisCommand(ctx, "KEYS *");
+			}
 			rctx->cmd = REDIS_KEYS;
 			break;
 


### PR DESCRIPTION
KEYS * is very costly on large databases

With this small change, you can query the keys using a simple equals clause using the keys template:

`SELECT * FROM keys_table WHERE key = 'key-name:*'`